### PR TITLE
Fix PipeTest.DoubleReadable test

### DIFF
--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -119,11 +119,13 @@ int tlb_evl_remove(struct tlb_event_loop *loop, tlb_handle subscription) {
   if (sub->sub_mode & TLB_SUB_ONESHOT) {
     switch ((enum tlb_sub_state)sub->oneshot_state) {
       case TLB_STATE_SUBBED:
+        TLB_LOG_EVENT(sub, "ONESHOT & SUBBED, unsubbing and freeing");
         result = tlb_evl_impl_unsubscribe(loop, sub);
         tlb_free(loop->alloc, sub);
         break;
 
       case TLB_STATE_RUNNING:
+        TLB_LOG_EVENT(sub, "ONESHOT & RUNNING, Setting oneshot_state");
         sub->oneshot_state = TLB_STATE_UNSUBBED;
         break;
 
@@ -132,6 +134,7 @@ int tlb_evl_remove(struct tlb_event_loop *loop, tlb_handle subscription) {
         break;
     }
   } else {
+    TLB_LOG_EVENT(sub, "!ONESHOT, unsubbing and freeing");
     result = tlb_evl_impl_unsubscribe(loop, sub);
     tlb_free(loop->alloc, sub);
   }

--- a/source/linux/event_loop_epoll.c
+++ b/source/linux/event_loop_epoll.c
@@ -166,10 +166,12 @@ int tlb_evl_handle_events(struct tlb_event_loop *loop, size_t budget, int timeou
 
     TLB_LOG_EVENT(sub, "Handling");
 
+    /* Cache this off because sub can become invalid during on_event */
+    const uint8_t sub_mode = sub->sub_mode;
     sub->oneshot_state = TLB_STATE_RUNNING;
     sub->on_event(sub, s_events_from_epoll(event), sub->userdata);
 
-    if (sub->sub_mode & TLB_SUB_ONESHOT) {
+    if (sub_mode & TLB_SUB_ONESHOT) {
       switch ((enum tlb_sub_state)sub->oneshot_state) {
         case TLB_STATE_SUBBED:
           /* Not possible */


### PR DESCRIPTION
Because subscriptions are edge triggered, we expect 1 trigger despite 2 writes in single thread mode, because events aren't triggered until after the writes are completed.