### PR TITLE
Re-arm fd race condition fix

### DIFF
--- a/source/bsd/event_loop_kqueue.c
+++ b/source/bsd/event_loop_kqueue.c
@@ -162,8 +162,8 @@ int tlb_evl_handle_events(struct tlb_event_loop *loop, size_t budget, int timeou
       case TLB_STATE_RUNNING:
         /* Resubscribe the event */
         sub->state = TLB_STATE_SUBBED;
-        s_kqueue_change(loop, sub, EV_ENABLE);
         TLB_LOG_EVENT(sub, "Set to SUBBED");
+        s_kqueue_change(loop, sub, EV_ENABLE);
         break;
 
       case TLB_STATE_UNSUBBED:

--- a/source/linux/event_loop_epoll.c
+++ b/source/linux/event_loop_epoll.c
@@ -178,9 +178,10 @@ int tlb_evl_handle_events(struct tlb_event_loop *loop, size_t budget, int timeou
 
       case TLB_STATE_RUNNING:
         /* Resubscribe the event */
-        s_epoll_change(loop, sub, EPOLL_CTL_MOD);
         sub->state = TLB_STATE_SUBBED;
         TLB_LOG_EVENT(sub, "Set to SUBBED");
+        /* This line needs to be last here to prevent race conditions */
+        s_epoll_change(loop, sub, EPOLL_CTL_MOD);
         break;
 
       case TLB_STATE_UNSUBBED:


### PR DESCRIPTION
This spurious failure was caused by calling `s_epoll_change` too early on a machine with 1 thread, which would cause another thread to wake up and process events before the state had been updated correctly.